### PR TITLE
Fix bad condition for using type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Icon
 
 /ChromePhp.php
 node_modules
+.idea

--- a/admin/class-accordion-slider-admin.php
+++ b/admin/class-accordion-slider-admin.php
@@ -972,9 +972,19 @@ class BQW_Accordion_Slider_Admin {
 	 */
 	public function load_content_type_settings( $type, $panel_settings = NULL ) {
 		$panel_default_settings = BQW_Accordion_Slider_Settings::getPanelSettings();
-		$type = isset( $_POST['type'] ) && array_key_exists( $_POST['type'], $panel_default_settings['content_type']['available_values'] ) ? $_POST['type'] : $panel_default_settings['content_type']['default_value'];
-		$panel_settings = BQW_Accordion_Slider_Validation::validate_panel_settings( json_decode( stripslashes( $_POST['data'] ), true ) );
- 
+        if (isset($_POST['type'])) {
+            if (array_key_exists($_POST['type'], $panel_default_settings['content_type']['available_values'])) {
+                $type = $_POST['type'];
+            } else {
+                $type = $panel_default_settings['content_type']['default_value'];
+            }
+        }
+        if (isset($_POST['data'])) {
+            $panel_settings = BQW_Accordion_Slider_Validation::validate_panel_settings(
+                json_decode(stripslashes($_POST['data']), true)
+            );
+        }
+
 		if ( $type === 'posts' ) {
 			$post_names = $this->get_post_names();
 


### PR DESCRIPTION
When you click on "Edit settings", the pop-up doesn't display the correct template. 
This happens because the code takes either the value of $_POST or the default value.
However, the current panel value is received as a function parameter.
The fix allows you to use the POST value only if it exists, and if it doesn't then use the default value.